### PR TITLE
feat(ci): restructure CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,51 +2,37 @@ name: Continuous integration
 
 on:
   push:
-    branches:
-    - main
+    branches: [ main ]
   pull_request:
-    branches:
-    - main
+    branches: [ main ]
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.10'
-      - name: Install
-        run: |
-          python3 -m venv .env
-          source .env/bin/activate
-          python -m pip install -U pip
-          make install-dev
-      - name: Lint
-        run: |
-          source .env/bin/activate
-          make lint
-  tests:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.os }}
+    
     strategy:
-      matrix:
-        python-version: ['3.10']
-
+        matrix:
+          python-version: [ '3.8','3.9', '3.10' ]
+          os: [ubuntu-latest]
+        
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install
-      run: |
-        python3 -m venv .env
-        source .env/bin/activate
-        make install
-        make install-dev
-    - name: Unit tests
-      run: |
-        source .env/bin/activate
-        make test
+        - uses: actions/checkout@v3
+        - name: Setup Python ${{ matrix.python-version }}
 
+        - uses: actions/setup-python@v4
+          with:
+            python-version: ${{ matrix.python-version }}
+            cache: 'pip'
+
+        - name: Install deps
+          run: |
+            make install
+            make install-dev
+
+        - name: Lint
+          run: |
+            make lint
+
+        - name: Unit Tests
+          run: |
+            make test


### PR DESCRIPTION
This PR aims to restructure the CI workflow as follows:

- Test on multiple python versions (`3.8`, `3.9` and `3.10`).
- Use an updated version of `actions/setup-python` so as to allow the caching of `pip`.
- drop the use of virtual environments as we enable `pip` caching.
- merge lint and test into a single job.